### PR TITLE
Update node and remove a debug output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:7
+FROM node:8
 
 RUN apt-get update \
         && apt-get install -y jshon python-pip python-dev \

--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -24,7 +24,6 @@ case `branchType $branch` in
   isDefaultBranch=false
   ;;
 esac
-echo $isDefaultBranch
 
 # read current version
 version=$(npm show $repoSlug version)


### PR DESCRIPTION
Node 8.x is the latest version that [receives long term support](https://github.com/nodejs/Release#release-schedule). The next LTS release is scheduled for October 2018, so I think we shouldn't have to upgrade again for about a year and at that point we have another year of time to actually do the upgrade.

Previously we've been on node 7, which doesn't receive LTS and some tools started complaining that we use an unsupported version, so ideally we only stick to LTS releases from now on.