### PR TITLE
SFM-1475 use HTTP orgin if SSH_KEY isn't provided (quick)

### DIFF
--- a/bin/initRepo.sh
+++ b/bin/initRepo.sh
@@ -3,26 +3,26 @@
 # sets up an ssh key and enables push access to the git repository
 #
 
-owner=${BITBUCKET_REPO_OWNER?}
-slug=${BITBUCKET_REPO_SLUG?}
 user=${GIT_USER_NAME?}
 email=${GIT_USER_EMAIL?}
 
-if [ ! -e ~/.ssh/id_rsa ]; then
+if [ -n "$SSH_KEY" ]; then
   key=${SSH_KEY?}
+
   echo "adding ssh key"
   mkdir -p ~/.ssh
   echo $key | base64 -d > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
-else
-  echo "using existing ssh key"
-fi
 
-echo "adding bitbucket.org as known host"
-ssh-keyscan -t rsa bitbucket.org >> ~/.ssh/known_hosts
+  echo "adding bitbucket.org as known host"
+  ssh-keyscan -t rsa bitbucket.org >> ~/.ssh/known_hosts
+
+  echo "setting SSH remote URL"
+  git remote set-url origin ${BITBUCKET_GIT_SSH_ORIGIN?}
+else
+  echo "setting HTTP remote URL"
+  git remote set-url origin ${BITBUCKET_GIT_HTTP_ORIGIN?}
+fi
 
 echo "configuring git user"
 git config --global user.name "$user"
 git config --global user.email "$email"
-
-echo "setting remote url"
-git remote set-url origin git@bitbucket.org:${owner}/${slug}.git


### PR DESCRIPTION
bitbucket [started supporting non-SSH git push a while ago](https://community.atlassian.com/t5/Bitbucket-Pipelines-articles/Pushing-back-to-your-repository/ba-p/958407) so we should be able to build without `SSH_KEY`. Note that setting `BITBUCKET_GIT_HTTP_ORIGIN` shouldn't be necessary but probably shouldn't harm either.