### PR TITLE
Update to node.js 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:12
 
 RUN apt-get update \
         && apt-get install -y jshon python-pip python-dev \


### PR DESCRIPTION
node.js 8 runs out of maintenance by the end of this year. Therefore we should use node.js 12 for new projects and potentially also update the other repos at some point (/cc @symn).

node.js 12 will be maintained until 2022-04-01 (see [release schedule](https://nodejs.org/en/about/releases/)).

If this change is ok, can you merge the PR for me and tag the published docker image? I think you mentioned that this needs to be done manually.