### PR TITLE
add molindo-pipelines.sh profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,4 @@ RUN apt-get update \
         && rm -rf /var/lib/apt/lists/*
 
 ADD bin /usr/local/bin
+ADD profile /etc/profile.d

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Built and [hosted on Docker Hub](https://hub.docker.com/r/molindo/molindo-pipeli
 - `BITBUCKET_REPO_SLUG` - slug of the repository name
 - `GIT_USER_NAME` - user name of a git user that has push access to the repository
 - `GIT_USER_EMAIL` - email of a git user that has push access to the repository
+- `NPM_REGISTRY_USER` - npm registry user
+- `NPM_REGISTRY_PASS` - npm registry password
+- `NPM_REGISTRY_EMAIL` - npm registry email
 
 
 ### Add bitbucket-pipelines.yml

--- a/README.md
+++ b/README.md
@@ -37,8 +37,13 @@ image: molindo/molindo-pipelines:cypress
 pipelines:
   default:
     - step:
+        caches:
+          - node
         script:
+          - . /etc/profile
           - initRepo.sh
+          - yarn install
+          - npm run lint
           - $(npm bin)/cypress verify
           - dockerBuild.sh
           - triggerBamboo.sh

--- a/profile/molindo-pipelines.sh
+++ b/profile/molindo-pipelines.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+if [ -n "$NPM_REGISTRY_USER" ] && [ -n "$NPM_REGISTRY_PASS" ]; then
+    echo "exporting NPM_REGISTRY_AUTH for user $NPM_REGISTRY_USER"
+    export NPM_REGISTRY_AUTH=$( echo -n "${NPM_REGISTRY_USER}:${NPM_REGISTRY_PASS}" | openssl base64 )
+elif [ -n "$NPM_REGISTRY_AUTH" ]; then
+    echo "NPM_REGISTRY_AUTH not available"
+    exit 1
+fi


### PR DESCRIPTION
optionally allow auth via `NPM_REGISTRY_USER` and `NPM_REGISTRY_PASS` rather than `NPM_REGISTRY_AUTH` only (merged from `nodejs` branch)