### PR TITLE
upgrade to cypress/base:12.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/base:8
+FROM cypress/base:12.6.0
 
 RUN apt-get update \
         && apt-get install -y jshon python-pip python-dev \


### PR DESCRIPTION
[currently built](https://cloud.docker.com/u/molindo/repository/registry-1.docker.io/molindo/molindo-pipelines/builds/7ee90014-e4df-42eb-a30b-fe6e7c204270) with `:cypress-12` tag