### PR TITLE
Override pom scm connection (quick)

### DIFF
--- a/maven/bin/build.xml
+++ b/maven/bin/build.xml
@@ -213,6 +213,7 @@
 			<arg value="-Dscm.checkLocalModification.skip=${isFeatureBranch}" />
 			<arg value="scm:tag" />
 			<arg value="-DpushChanges=${pushChanges}" />
+			<arg value="-DdeveloperConnectionUrl=${git.origin}" if:set="git.origin" />
 			<arg value="-Dtag=${version}" />
 		</exec>
 		<antcall target="setVersion">
@@ -255,6 +256,7 @@
 			<arg value="scm:checkin" />
 			<arg value="-Dmessage=${defaultBuildtoolFilter} updated internal dependencies" />
 			<arg value="-DpushChanges=${pushChanges}" />
+			<arg value="-DdeveloperConnectionUrl=${git.origin}" if:set="git.origin" />
 		</exec>
 	</target>
 

--- a/maven/bin/build.xml
+++ b/maven/bin/build.xml
@@ -213,7 +213,7 @@
 			<arg value="-Dscm.checkLocalModification.skip=${isFeatureBranch}" />
 			<arg value="scm:tag" />
 			<arg value="-DpushChanges=${pushChanges}" />
-			<arg value="-DdeveloperConnectionUrl=${git.origin}" if:set="git.origin" />
+			<arg value="-DdeveloperConnectionUrl=scm:git:${git.remote.origin.url}" if:set="git.remote.origin.url" />
 			<arg value="-Dtag=${version}" />
 		</exec>
 		<antcall target="setVersion">
@@ -256,7 +256,7 @@
 			<arg value="scm:checkin" />
 			<arg value="-Dmessage=${defaultBuildtoolFilter} updated internal dependencies" />
 			<arg value="-DpushChanges=${pushChanges}" />
-			<arg value="-DdeveloperConnectionUrl=${git.origin}" if:set="git.origin" />
+			<arg value="-DdeveloperConnectionUrl=scm:git:${git.remote.origin.url}" if:set="git.remote.origin.url" />
 		</exec>
 	</target>
 

--- a/maven/bin/deploy.sh
+++ b/maven/bin/deploy.sh
@@ -12,9 +12,4 @@ if [ "$USE_DYNAMO_DB" != true ]; then
     args="-DincrementalVersion=${BITBUCKET_BUILD_NUMBER?}"
 fi
 
-ant -f /usr/local/bin/build.xml -Dbasedir=. \
-  -Dgit.branch=${branch} \
-  -Dgit.origin=`git remote get-url origin` \
-  -Dmvn=/usr/bin/mvn \
-  -Daws=/usr/local/bin/aws \
-  $args dist
+ant -f /usr/local/bin/build.xml -Dbasedir=. -Dgit.branch=${branch} -Dmvn=/usr/bin/mvn -Daws=/usr/local/bin/aws $args dist

--- a/maven/bin/deploy.sh
+++ b/maven/bin/deploy.sh
@@ -12,4 +12,9 @@ if [ "$USE_DYNAMO_DB" != true ]; then
     args="-DincrementalVersion=${BITBUCKET_BUILD_NUMBER?}"
 fi
 
-ant -f /usr/local/bin/build.xml -Dbasedir=. -Dgit.branch=${branch} -Dmvn=/usr/bin/mvn -Daws=/usr/local/bin/aws $args dist
+ant -f /usr/local/bin/build.xml -Dbasedir=. \
+  -Dgit.branch=${branch} \
+  -Dgit.origin=`git remote get-url origin` \
+  -Dmvn=/usr/bin/mvn \
+  -Daws=/usr/local/bin/aws \
+  $args dist


### PR DESCRIPTION
automatically use `${git.remote.origin.url}` from git-commit-id-plugin, i.e. `$BITBUCKET_GIT_HTTP_ORIGIN` as set by `./bin/initRepo.sh`