### PR TITLE
support triggering of child plans (quick)

### DIFF
--- a/cypress/bin/dockerBuild.sh
+++ b/cypress/bin/dockerBuild.sh
@@ -28,7 +28,7 @@ if [ -e $tags ]; then
 	echo "using existing $tags"
 else
 	echo "generating default $tags"
-	echo -n $registry/$target > $tags
+	echo -n $target > $tags
 fi
 
 # ECR login

--- a/maven/bin/dockerBuild.sh
+++ b/maven/bin/dockerBuild.sh
@@ -28,7 +28,7 @@ if [ -e $tags ]; then
 	echo "using existing $tags"
 else
 	echo "generating default $tags"
-	echo -n $registry/$target > $tags
+	echo -n $target > $tags
 fi
 
 # ECR login

--- a/nodejs/bin/dockerBuild.sh
+++ b/nodejs/bin/dockerBuild.sh
@@ -28,7 +28,7 @@ if [ -e $tags ]; then
 	echo "using existing $tags"
 else
 	echo "generating default $tags"
-	echo -n $registry/$target > $tags
+	echo -n $target > $tags
 fi
 
 # ECR login


### PR DESCRIPTION
allow adding a `BAMBOO_CHILD_PLAN` instead of a `BAMBOO_PLAN`, i.e. the `*-tim` plan. The difference is that no branches will be created (because the branch might not exist) and the build isn't customized with commit id (because the commit id won't exist)