### PR TITLE
only read properties from parent POM in multimodule projects (quick)

### DIFF
--- a/maven/bin/build.xml
+++ b/maven/bin/build.xml
@@ -82,6 +82,7 @@
 		<exec executable="${mvn}" failonerror="true">
 			<arg value="--batch-mode" />
 			<arg value="--settings=settings.xml" />
+			<arg value="--projects=." />
 			<arg value="-Ddeployment=true" />
 			<arg value="-Dbuild.properties=${build.properties}" />
 			<arg value="initialize" />


### PR DESCRIPTION
problem with duplicate tags resulted from overriding `project.artifactId` nondeterministicly from any submodule