### PR TITLE
add artifactId to git tag to avoid conflicts (quick)

### DIFF
--- a/maven/bin/build.xml
+++ b/maven/bin/build.xml
@@ -49,7 +49,7 @@
 		</antcall>
 
 		<antcall target="tagVersion">
-			<param name="version" value="${build.version.release}" />
+			<param name="version" value="${project.artifactId}-${build.version.release}" />
 		</antcall>
 
 		<antcall target="updateAndPushDependencies" />


### PR DESCRIPTION
having different artifactIds in the same repository (e.g. `molindo-java8-pom` and `molindo-java11-pom`) may lead to tag name conflicts if we only use the version.